### PR TITLE
invoke done for successful jpm runs

### DIFF
--- a/tasks/jpm.js
+++ b/tasks/jpm.js
@@ -56,7 +56,7 @@ module.exports = function(grunt) {
       debug: grunt.option('firefox-debugger'),
       profile: grunt.option('firefox-profile') || process.env.FIREFOX_PROFILE,
       binary: grunt.option('firefox-bin') || process.env.FIREFOX_BIN
-    }).then(null, function(e) {
+    }).then(done, function(e) {
       grunt.log.error("Error running Firefox:", e);
     });
   });


### PR DESCRIPTION
Needed to be able to invoke `jpm:run` tasks along with other tasks, as otherwise grunt doesn't know the task is done and hangs. Example that this change fixes: https://github.com/freedomjs/freedom-for-firefox/blob/soycode-jpm/tasks/build-test-addon.js#L129-131
