### PR TITLE
Add jpm:test grunt task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+tmp
+*.xpi
+.tern-port

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+sudo: false
+language: node_js
+node_js:
+  - "0.10"
+  - "4"
+  - "5"
+
+addons:
+  firefox: latest-beta
+
+before_install:
+ - "export DISPLAY=:99.0"
+ - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16 -extension RANDR"
+
+before_script:
+  - npm install grunt-cli -g
+
+script:
+  - export FIREFOX_BIN=`which firefox`
+  - npm test

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,47 @@
+/*
+ * grunt-jpm
+ * https://github.com/rpl/grunt-jpm
+ *
+ * Copyright (c) 2016 Luca Greco
+ * Licensed under the MPL-2 license.
+ */
+
+'use strict';
+
+module.exports = function(grunt) {
+
+  // Project configuration.
+  grunt.initConfig({
+    // Before generating any new files, remove any previously-created files.
+    clean: {
+      tests: ['tmp'],
+    },
+
+    jpm: {
+      options: {
+        src: 'test/fixtures/test-addon',
+        xpi: 'tmp/dist'
+      }
+    },
+
+    // Unit tests.
+    nodeunit: {
+      tests: ['test/*_test.js'],
+    },
+
+  });
+
+  // Actually load this plugin's task(s).
+  grunt.loadTasks('tasks');
+
+  // These plugins provide necessary tasks.
+  grunt.loadNpmTasks('grunt-contrib-clean');
+  grunt.loadNpmTasks('grunt-contrib-nodeunit');
+
+  // Whenever the "test" task is run, first clean the "tmp" dir, then run this
+  // plugin's task(s), then test the result.
+  grunt.registerTask('test', ['clean', 'jpm:xpi', 'jpm:test', 'nodeunit']);
+
+  // By default, lint and run all tests.
+  grunt.registerTask('default', ['test']);
+};

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.3",
   "description": "Grunt Mozilla JPM Plugin",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "grunt test"
   },
   "repository": {
     "type": "git",
@@ -26,11 +26,16 @@
     "url": "https://github.com/rpl/grunt-jpm/issues"
   },
   "dependencies": {
-    "grunt": "~0.4.0",
+    "es6-promise": "^3.0.2",
     "jpm": "~1.0.5",
     "mkdirp": "^0.5.1"
   },
   "peerDependencies": {
-    "grunt": "~0.4.0"
+    "grunt": "~0.4.1"
+  },
+  "devDependencies": {
+    "grunt": "~0.4.1",
+    "grunt-contrib-clean": "^0.7.0",
+    "grunt-contrib-nodeunit": "^0.4.1"
   }
 }

--- a/test/fixtures/test-addon/package.json
+++ b/test/fixtures/test-addon/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "test-addon",
+  "version": "1.0.0",
+  "id": "test-addon@alcacoop.it",
+  "main": "./lib/main.js"
+}

--- a/test/fixtures/test-addon/test/test-main.js
+++ b/test/fixtures/test-addon/test/test-main.js
@@ -1,0 +1,17 @@
+var main = require("../lib/main");
+
+var { Cc, Ci } = require("chrome");
+var file = require("sdk/io/file");
+
+var currDir = Cc["@mozilla.org/file/directory_service;1"]
+                .getService(Ci.nsIDirectoryServiceProvider)
+                .getFile("CurWorkD", {}).path;
+
+exports["test ok"] = function(assert) {
+  var fh = file.open(file.join(currDir, "tmp", "test_run.txt"), "w");
+  fh.write("OK");
+  fh.close();
+  assert.ok(true, "it works");
+};
+
+require("sdk/test").run(exports);

--- a/test/grunt_jpm_test.js
+++ b/test/grunt_jpm_test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var grunt = require('grunt');
+var path = require('path');
+
+/*
+  ======== A Handy Little Nodeunit Reference ========
+  https://github.com/caolan/nodeunit
+
+  Test methods:
+    test.expect(numAssertions)
+    test.done()
+  Test assertions:
+    test.ok(value, [message])
+    test.equal(actual, expected, [message])
+    test.notEqual(actual, expected, [message])
+    test.deepEqual(actual, expected, [message])
+    test.notDeepEqual(actual, expected, [message])
+    test.strictEqual(actual, expected, [message])
+    test.notStrictEqual(actual, expected, [message])
+    test.throws(block, [error], [message])
+    test.doesNotThrow(block, [error], [message])
+    test.ifError(value)
+*/
+
+exports.grunt_jpm = {
+  setUp: function(done) {
+    // setup here if necessary
+    done();
+  },
+  jpm_xpi: function (test) {
+    test.expect(1);
+
+    var xpi_build = path.resolve("tmp", "dist", "test-addon@alcacoop.it-1.0.0.xpi");
+    test.ok(grunt.file.exists(xpi_build), "xpi file should be built into 'tmp/dist'");
+
+    test.done();
+  },
+  jpm_test: function(test) {
+    test.expect(1);
+
+    var test_result_file = path.resolve("tmp", "test_run.txt");
+    test.ok(grunt.file.exists(test_result_file), "grunt jpm:test should run addon unit tests");
+    test.done();
+  }
+};


### PR DESCRIPTION
This PR introduces a new "jpm:test" grunt task (and a clean up of the module) and a basic test suite which run on travis "jpm:xpi" and "jpm:test" and check their results.
