### PR TITLE
Added signing support

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "grunt": "~0.4.0",
+    "jetpack-id": "^1.0.0",
     "jpm": "~1.0.5",
     "mkdirp": "^0.5.1"
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "grunt": "~0.4.0",
     "jetpack-id": "^1.0.0",
-    "jpm": "~1.0.5",
+    "jpm": "~1.0.6",
     "mkdirp": "^0.5.1"
   },
   "peerDependencies": {

--- a/tasks/jpm.js
+++ b/tasks/jpm.js
@@ -1,7 +1,10 @@
 var path = require('path');
 var mkdirp = require('mkdirp');
+var getId = require('jetpack-id');
+var fs = require('fs');
 var jpm_utils = require("jpm/lib/utils");
 var jpm_xpi = require("jpm/lib/xpi");
+var jpm_sign = require("jpm/lib/sign").sign;
 var jpm_run = require("jpm/lib/run");
 
 const XPI_PATH = "./tmp/";
@@ -40,6 +43,62 @@ module.exports = function(grunt) {
           grunt.log.ok("Generated XPI: ", res);
         }, function(e) {
           grunt.log.error("Error during XPI build:", e);
+        }).then(function () {
+          done(true);
+        });
+      });
+    });
+  });
+
+  grunt.registerTask('jpm:sign', "sign or sign & create firefox xpi", function() {
+    var jpm_env = {};
+
+    try {
+      jpm_env = prepareJPMGruntTask();
+    } catch(e) {
+      grunt.log.error("Error preparing JPM Grunt Task: " + e);
+      return;
+    }
+
+    var done = this.async();
+
+    var dirs = jpm_env.dirs;
+
+    //jpm_env.manifest is a Promise
+    jpm_env.manifest.then(function(manifest) {
+      // Ensure dest xpi dir exists
+      mkdirp(dirs.xpi, function(error) {
+        if (error) {
+          grunt.log.error("Error creating xpi dest dir: " + error);
+          return;
+        }
+
+        //This is lifted from jpm's xpi.js, so we can support jpm:xpi -> jpm:sign or just jpm:sign
+        var xpiVersion = manifest.version ? ("-" + manifest.version) : "";
+        var xpiName = getId(manifest) + xpiVersion + '.xpi';
+        var xpiDir = dirs.xpi;
+        if (xpiDir[xpiDir.length - 1] !== '/') xpiDir += '/';
+
+        var fullXPIPath = xpiDir + xpiName;
+        var xpiPath = false;
+        try {
+          fs.accessSync(fullXPIPath);
+          xpiPath = fullXPIPath;
+        }
+        catch(e){}
+
+        jpm_sign({
+          verbose: grunt.option('debug'),
+          addonDir: dirs.src,
+          xpiPath: dirs.xpi,
+          xpi: xpiPath,
+          apiKey: dirs.apiKey,
+          apiSecret: dirs.apiSecret,
+          timeout: dirs.timeout
+        }).then(function(res) {
+          grunt.log.ok("Signed XPI: ", res);
+        }, function(e) {
+          grunt.log.error("Error while signing xpi:", e);
         }).then(function () {
           done(true);
         });
@@ -88,6 +147,9 @@ module.exports = function(grunt) {
 function resolveDirsFromConfig(grunt_config, name) {
   return {
     src: path.resolve(grunt_config["src"]),
-    xpi: path.resolve(grunt_config["xpi"] || XPI_PATH)
+    xpi: path.resolve(grunt_config["xpi"] || XPI_PATH),
+    apiKey: grunt_config.apiKey,
+    apiSecret: grunt_config.apiSecret,
+    timeout: grunt_config.timeout
   };
 }


### PR DESCRIPTION
I used `jpm:xpi` as the basis for sign and had to do some digging through jpm's source to support a slightly improved workflow and integration. Normally, `jpm sign` requires an explicit file if you want to use an already generated xpi, so I lifted the logic to determine the xpi name and check for the existence of an xpi first before letting sign generate another one.
